### PR TITLE
Text Box, Music Cleanup

### DIFF
--- a/TrySomethingNew/SceneManager.cpp
+++ b/TrySomethingNew/SceneManager.cpp
@@ -19,13 +19,17 @@ SceneManager::SceneManager() {
 }
 
 SceneManager::~SceneManager() {
+	// Quit SDL_Mixer
+	Mix_FreeMusic(mAssets->music.TitleMusic);
+	Mix_FreeMusic(mAssets->music.IntroMusic);
+	mAssets->music.TitleMusic = NULL;
+	mAssets->music.IntroMusic = NULL;
+	Mix_Quit();
 	// Release/free SDL Graphics
 	Graphics::Release();
 	Assets::Release();
 	this->mGraphics = NULL;
 	this->mAssets = NULL;
-	// Quit SDL_Mixer
-	Mix_Quit();
 }
 
 bool SceneManager::Init() {

--- a/TrySomethingNew/Scenes/Intro.cpp
+++ b/TrySomethingNew/Scenes/Intro.cpp
@@ -30,8 +30,8 @@ void Intro::SceneStart() {
 	
 	// Text objects
 	this->TextObjects.EnterShopName = this->AddText("SHOP NAME:", 8, 8);
-	this->TextObjects.ShopNameEntry = this->AddText("", 8, 16);
-	this->ShopName = this->TextObjects.ShopNameEntry->GetText();
+	this->TextBoxObjects.ShopNameEntry = this->AddTextBox(25, 8, 16);
+	this->ShopName = this->TextBoxObjects.ShopNameEntry->GetText();
 
 	// Start with text entry off
 	SDL_StopTextInput();
@@ -54,9 +54,8 @@ void Intro::HandleEvent(SDL_Event * Event) {
 			}
 		}
 		// If we're editing and hit backspace, erase a character.
-		if (this->EditName && Event->key.keysym.sym == SDLK_BACKSPACE && this->ShopName->length() > 0) {
-			this->ShopName->pop_back();
-			this->UpdateText(this->TextObjects.ShopNameEntry);
+		if (this->EditName && Event->key.keysym.sym == SDLK_BACKSPACE) {
+			this->TextBoxObjects.ShopNameEntry->DeleteText();
 		}
 		break;
 
@@ -65,9 +64,8 @@ void Intro::HandleEvent(SDL_Event * Event) {
 
 	case SDL_TEXTINPUT:
 		// As long as we are editing the name and it's less than 25 characters, add characters.
-		if (this->EditName && this->ShopName->length() < 25) {
-			this->ShopName->append(Event->text.text);
-			this->UpdateText(this->TextObjects.ShopNameEntry);
+		if (this->EditName) {
+			this->TextBoxObjects.ShopNameEntry->AppendText(Event->text.text);
 		}
 		break;
 	case SDL_TEXTEDITING:
@@ -86,12 +84,15 @@ void Intro::Update(Uint32 timeStep) {
 		// Go to title.
 		this->mManager->StartScene(Scene_TitleScreen);
 	}
+
+	this->TextBoxObjects.ShopNameEntry->SetActive(this->EditName);
 }
 
 void Intro::Render() {
 	// Render graphics to buffer
 	// If I find any game logic in here, I'll slap myself silly
 	for (int i = 0; i < (int) this->mImages.size(); i++) {
+		if(this->mImages[i]->IsVisible())
 		this->mManager->GetGraphics()->DrawTextureAtLocation(
 			this->mImages[i]->GetImage()->texture,
 			this->mImages[i]->GetImage()->rect,

--- a/TrySomethingNew/Scenes/Scene.cpp
+++ b/TrySomethingNew/Scenes/Scene.cpp
@@ -20,16 +20,14 @@ ImageData* Scene::AddText(std::string _text, int _x, int _y) {
 	ImageData* textImageData = new ImageData();
 	
 	// Generate text image
-	textImageData->GetImage()->texture = this->mManager->GetGraphics()->LoadText(
-			this->mManager->GetAssets()->fonts.PrintChar21_8,
-			_text,
-			255,
-			255,
-			255,
-			0);
-	textImageData->GetImage()->rect = Graphics::CreateRect(0, 0, 0, 0);
-	SDL_QueryTexture(textImageData->GetImage()->texture, NULL, NULL, &(textImageData->GetImage()->rect->w), &(textImageData->GetImage()->rect->h));
-	
+	textImageData->SetTexture(Graphics::Instance()->LoadText(
+		this->mManager->GetAssets()->fonts.PrintChar21_8,
+		_text,
+		255,
+		255,
+		255,
+		0));
+
 	// Store text image in image data
 	textImageData->CreateDrawRect();
 	textImageData->SetDrawRectXY(_x, _y);
@@ -41,17 +39,9 @@ ImageData* Scene::AddText(std::string _text, int _x, int _y) {
 	return textImageData;
 }
 
-void Scene::UpdateText(ImageData * textImage) {
-	// Update texture with new text
-	textImage->SetTexture(this->mManager->GetGraphics()->LoadText(
-		this->mManager->GetAssets()->fonts.PrintChar21_8,
-		*(textImage->GetText()),
-		255,
-		255,
-		255,
-		0));
-	// Set new image rect size
-	SDL_QueryTexture(textImage->GetImage()->texture, NULL, NULL, &(textImage->GetImage()->rect->w), &(textImage->GetImage()->rect->h));
-	textImage->UpdateDrawRect();
+TextBox* Scene::AddTextBox(size_t _size, int _x, int _y)
+{
+	TextBox* textBox = new TextBox(_size, _x, _y);
+	this->mImages.push_back(textBox);
+	return textBox;
 }
-

--- a/TrySomethingNew/Scenes/Scene.h
+++ b/TrySomethingNew/Scenes/Scene.h
@@ -47,7 +47,7 @@ public:
 	void SetManager(SceneManager* manager) { this->mManager = manager; }
 	void SetSceneName(SceneName name) { this->mSceneName = name; }
 	ImageData* AddText(std::string _text, int _x, int _y);
-	void UpdateText(ImageData* textImage);
+	TextBox* AddTextBox(size_t _size, int _x, int _y);
 
 	// Scene virtual funcs
 	virtual void LoadGameObjects() = 0;
@@ -98,8 +98,10 @@ protected:
 	std::string* ShopName;
 	struct {
 		ImageData* EnterShopName;
-		ImageData* ShopNameEntry;
 	} TextObjects;
+	struct {
+		TextBox* ShopNameEntry;
+	} TextBoxObjects;
 public:
 	// Scene ctor
 	Intro();


### PR DESCRIPTION
- Assets.h
-- Added Visible bool to ImageData to specify if image is visible. Set to true by default.
-- ImageData::IsVisible() and ImageData::SetVisible() helper methods added.
-- ImageData::SetTexture() updated to not only set the texture, but also update the texture rect to match (and create a rect if none exists)
-- TextBox class added, derives from ImageData. Allows text entry/deletion and dynamic texture/rect modification. Also has active state to determine if * cursor is drawn or if text can be entered/deleted.

- Scene.h
-- Scene::AddTextBox() method added for adding text boxes into a scene. Returns a TextBox pointer and adds the text box to the scene image vector.
-- Scene::UpdateText() removed, now handled by TextBox object.
-- Intro::TextBoxObjects struct added to track text boxes in the scene.
-- ShopNameEntry converted into a TextBoxObject

- Scene.cpp
-- Scene::AddText() reworked to only set the texture for an Image in an ImageData object. ImageData will handle the rest for the Image texture and rect.
-- Scene:AddTextBox() creates a new TextBox object, sets text/position, adds the image to the scene image list, then returns a pointer to the TextBox.
-- Scene UpdateText() removed, TextBox objects now perform the heavy lifting.

- Intro.cpp
-- References to ShopNameEntry now use the struct TextBoxObjects.
-- ShopNameEntry now initialized with Scene::AddTextBox().
-- Text entry and deletion methods in Event() now use TextBox methods.
-- ShopNameEntry now set active based on EditName flag in Update().
-- ImageData will noly be rendered if IsVisible() is true in Render().

- SceneManager.cpp
-- Music is now freed properly in SceneManager::~SceneManager().