### PR TITLE
Sales Results Scene

### DIFF
--- a/TrySomethingNew/Data/ItemData.cpp
+++ b/TrySomethingNew/Data/ItemData.cpp
@@ -7,8 +7,10 @@ ItemData::ItemData(ItemName _name) {
 	this->Name = _name;
 	this->Type = GetItemType(this->GetName());
 	this->Quantity = 0;
+	this->BoughtQuantity = 0;
 	this->BuyPrice = GetItemBuyPrice(this->GetName());
 	this->SellPrice = 0;
+	this->SalesTotal = 0;
 }
 
 ItemType GetItemType(ItemData* _item) {

--- a/TrySomethingNew/Data/ItemData.h
+++ b/TrySomethingNew/Data/ItemData.h
@@ -32,8 +32,10 @@ protected:
 	ItemName	Name;
 	ItemType	Type;
 	int			Quantity;
+	int			BoughtQuantity;
 	int			BuyPrice;
 	int			SellPrice;
+	int			SalesTotal;
 
 public:
 	ItemData(ItemName _name);
@@ -41,12 +43,16 @@ public:
 	ItemName GetName() { return this->Name; }
 	ItemType GetType() { return this->Type; }
 	int GetQuantity() { return this->Quantity; }
+	int GetBoughtQuantity() { return this->BoughtQuantity; }
 	int GetBuyPrice() { return this->BuyPrice; }
 	int GetSellPrice() { return this->SellPrice; }
+	int GetSalesTotal() { return this->SalesTotal; }
 	void SetQuantity(int _qty) { this->Quantity = _qty; }
 	void AddQuantity(int _qty) { this->Quantity += _qty; }
 	void SubQuantity(int _qty) { this->Quantity -= _qty; }
+	void SetBoughtQuantity(int _qty) { this->BoughtQuantity = _qty; }
 	void SetSellPrice(int _price) { this->SellPrice = _price; }
+	void AddSalesTotal(int _purchase) { this->SalesTotal += _purchase; }
 };
 
 ItemType GetItemType(ItemData* _item);

--- a/TrySomethingNew/Data/PlayerData.cpp
+++ b/TrySomethingNew/Data/PlayerData.cpp
@@ -19,6 +19,10 @@ ItemData* PlayerData::GetInventoryItem(ItemName _name) {
 	return GetItemFromVector(_name, &this->Inventory);
 }
 
+void PlayerData::ClearInventory() {
+	this->Inventory = *GetInitialItemVector();
+}
+
 bool PlayerData::HasInventoryItem(ItemName _name) {
 	return (this->GetInventoryItem(_name)->GetQuantity() > 0) ? true : false;
 }
@@ -28,7 +32,7 @@ void PlayerData::SetInventoryQty(ItemName _name, int _qty) {
 }
 
 void PlayerData::GenerateForecast() {
-	switch (rand() % 4) {
+	switch (rand() % 6) {
 	case 1:
 		this->fweather = ForecastWeather::Weather_Cloudy;
 		break;
@@ -40,7 +44,7 @@ void PlayerData::GenerateForecast() {
 		break;
 	}
 
-	switch (rand() % 8) {
+	switch (rand() % 10) {
 	case 1:
 		this->fevent = ForecastEvent::Event_EConcert;
 		break;

--- a/TrySomethingNew/Data/PlayerData.h
+++ b/TrySomethingNew/Data/PlayerData.h
@@ -37,6 +37,7 @@ public:
 	void ResetPlayerData();
 
 	std::vector<ItemData*>* GetInventory() { return &this->Inventory; }
+	void ClearInventory();
 	ItemData* GetInventoryItem(ItemName _name);
 	bool HasInventoryItem(ItemName _name);
 	void SetInventoryQty(ItemName _name, int _qty);

--- a/TrySomethingNew/SceneManager.cpp
+++ b/TrySomethingNew/SceneManager.cpp
@@ -56,6 +56,7 @@ bool SceneManager::Init() {
 	this->AddScene(new Market());
 	this->AddScene(new SetPrices());
 	this->AddScene(new DaySales());
+	this->AddScene(new SalesResults());
 
 	// Initialize scenes
 	for (int i = 0; i < (int) this->sceneList.size(); i++)

--- a/TrySomethingNew/Scenes/DaySales.cpp
+++ b/TrySomethingNew/Scenes/DaySales.cpp
@@ -51,10 +51,10 @@ void DaySales::LoadImagesText() {
 	// Text
 	int shopX = 140 - ((this->mPlayerData->GetName().length() * 7) / 2);
 	this->TextObjects.ShopName = this->AddDaySalesText(this->mPlayerData->GetName(), shopX, 28);
-	this->TextObjects.DayText = this->AddDaySalesText("DAY:", 7, 171);
-	this->TextObjects.DayNum = this->AddDaySalesText(std::to_string(this->mPlayerData->GetDay()), 42, 171);
-	this->TextObjects.MoneyText = this->AddDaySalesText("MONEY:", 140, 171);
-	this->TextObjects.MoneyAmt = this->AddDaySalesText(std::to_string(this->Money + this->mPlayerData->GetMoney()), 189, 171);
+	this->TextObjects.DayText = this->AddDaySalesText("DAY:", 7, 164);
+	this->TextObjects.DayNum = this->AddDaySalesText(std::to_string(this->mPlayerData->GetDay()), 42, 164);
+	this->TextObjects.MoneyText = this->AddDaySalesText("MONEY:", 140, 164);
+	this->TextObjects.MoneyAmt = this->AddDaySalesText(std::to_string(this->Money + this->mPlayerData->GetMoney()), 189, 164);
 
 	// Disable all image/text visibility
 	for (std::vector<ImageData*>::iterator it = this->mImages.begin(); it != this->mImages.end(); it++)
@@ -227,6 +227,9 @@ void DaySales::GetPurchase(Customer* _customer) {
 		purchasedItem->SubQuantity(1);
 		// Add sell price to money amount
 		this->Money += purchasedItem->GetSellPrice();
+		// Add sale to item's sales total
+		purchasedItem->AddSalesTotal(1);
+		// Set money total text
 		this->TextObjects.MoneyAmt->SetText(std::to_string(this->Money + this->mPlayerData->GetMoney()));
 	}
 }
@@ -261,8 +264,15 @@ void DaySales::SEvent_DayRuntime3() {
 }
 
 void DaySales::SEvent_DayRuntimeEnd() {
+	// Set player inventory
+	for (std::vector<ItemData*>::iterator it = this->SellItems.begin(); it != this->SellItems.end(); it++) {
+		ItemData* item = this->mPlayerData->GetInventoryItem((*it)->GetName());
+		*item = **it;
+	}
+
+	// Set player money
 	this->mPlayerData->SetMoney(this->mPlayerData->GetMoney() + this->Money);
-	this->mPlayerData->SetDay(this->mPlayerData->GetDay() + 1);
+		
 	// Leave Day Sales screen
-	this->mManager->StartScene(Scene_Market);
+	this->mManager->StartScene(Scene_SalesResults);
 }

--- a/TrySomethingNew/Scenes/Market.cpp
+++ b/TrySomethingNew/Scenes/Market.cpp
@@ -150,7 +150,8 @@ void Market::SceneStart() {
 	this->SEvent_ShowMarketText();
 	this->EventFlags.MainSelection = true;
 
-	// Initialize buy vector
+	// Initialize buy vectors
+	this->mPlayerData->ClearInventory();
 	this->BuyData = *GetInitialItemVector();
 	this->BuyTotal = 0;
 
@@ -381,6 +382,7 @@ void Market::SEvent_SetBuyItem(SDL_Keycode _key) {
 void Market::SEvent_EndItemQtyEntry() {
 	// Get quantity entered. Invalid input will convert to 0.
 	this->ActiveItemData->SetQuantity(std::atoi(this->ActiveBuySelection->GetText()->c_str()));
+	this->ActiveItemData->SetBoughtQuantity(this->ActiveItemData->GetQuantity());
 
 	// Set text to sanitized number.
 	this->ActiveBuySelection->SetText(std::to_string(this->ActiveItemData->GetQuantity()));
@@ -486,8 +488,10 @@ void Market::SEvent_ExitGuide() {
 void Market::SEvent_Leave() {
 	if (this->mPlayerData->GetMoney() >= this->BuyTotal) {
 		// Set player inventory equal to items purchased
-		for (std::vector<ItemData*>::iterator it = this->BuyData.begin(); it != this->BuyData.end(); it++)
+		for (std::vector<ItemData*>::iterator it = this->BuyData.begin(); it != this->BuyData.end(); it++) {
 			this->mPlayerData->GetInventoryItem((*it)->GetName())->SetQuantity((*it)->GetQuantity());
+			this->mPlayerData->GetInventoryItem((*it)->GetName())->SetBoughtQuantity((*it)->GetQuantity());
+		}
 
 		// Set player money
 		this->mPlayerData->SetMoney(this->mPlayerData->GetMoney() - this->BuyTotal);

--- a/TrySomethingNew/Scenes/SalesResults.cpp
+++ b/TrySomethingNew/Scenes/SalesResults.cpp
@@ -1,0 +1,160 @@
+#include <algorithm>
+#include <string>
+#include <vector>
+#include "Assets.h"
+#include "Data\ItemData.h"
+#include "Data\PlayerData.h"
+#include "Graphics.h"
+#include "Scenes\Scene.h"
+#include "SceneManager.h"
+
+SalesResults::SalesResults() {
+	// Set current scene name
+	this->SetSceneName(Scene_SalesResults);
+}
+
+//// Scene funcs
+void SalesResults::ResetFlags() {
+	// Set flags to false
+	this->EventFlags.ExitToTitleScreen = false;
+	this->EventFlags.ExitResults = false;
+}
+
+void SalesResults::LoadImagesText() {
+	// Clear any existing drawn text.
+	this->mImages.clear();
+	this->SalesResultsText.clear();
+
+	//// Image objects
+
+	//// Text objects
+	for (int i = 0; i < (int) this->SellItems.size(); i++) {
+		int menuNum = i + 1;
+		int y = 36 + (i * 9);
+		// Add menu number and name
+		std::string menuName = std::to_string(menuNum) + ") " + GetItemString(this->SellItems[i]->GetName());
+		this->AddSalesResultsText(menuName, 7, y);
+		// Display # bought
+		this->AddSalesResultsText(std::to_string(this->SellItems[i]->GetBoughtQuantity()), 161, y);
+		// Display # sold
+		this->AddSalesResultsText(std::to_string(this->SellItems[i]->GetSalesTotal()), 203, y);
+		// Display money made from sales
+		this->AddSalesResultsText("DM" + std::to_string(this->SellItems[i]->GetSalesTotal() * this->SellItems[i]->GetSellPrice()), 231, y);
+	}
+
+	// Title
+	this->AddSalesResultsText("EOD SALES RESULTS", 84, 9);
+	// Headers
+	this->AddSalesResultsText("-INVENTORY-", 21, 27);
+	this->AddSalesResultsText("STOCK", 161, 27);
+	this->AddSalesResultsText("SOLD", 203, 27);
+	this->AddSalesResultsText("SALES", 238, 27);
+	// Day
+	this->AddSalesResultsText("DAY:", 7, 164);
+	this->AddSalesResultsText(std::to_string(this->mPlayerData->GetDay()), 42, 164);
+	// Total
+	this->AddSalesResultsText("MONEY:", 140, 164);
+	this->TextObjects.PlayerMoneyAmount = this->AddSalesResultsText(std::to_string(this->mPlayerData->GetMoney()), 189, 164);
+	// Press Return
+	this->AddSalesResultsText("- PRESS RETURN -", 84, 180);
+
+	for (std::vector<ImageData*>::iterator it = this->mImages.begin(); it != this->mImages.end(); it++)
+		(*it)->SetVisible(false);
+}
+
+void SalesResults::SceneStart() {
+	// Play Market music
+	Mix_HaltMusic();
+
+	// Reset Flags
+	this->ResetFlags();
+
+	// Get player inventory
+	this->GetCurrentPlayerInventory();
+
+	// Load Images and Text Images
+	this->LoadImagesText();
+
+	// Display main market text
+	this->SEvent_ShowSalesResultsText();
+}
+
+void SalesResults::HandleEvent(SDL_Event * Event) {
+	switch (Event->type) {
+	case SDL_KEYDOWN:
+		//// Exit event
+		if (Event->key.keysym.sym == SDLK_ESCAPE)
+			this->EventFlags.ExitToTitleScreen = true;
+		if (Event->key.keysym.sym == SDLK_RETURN)
+			this->SEvent_NextDay();
+		break;
+
+	case SDL_KEYUP:
+		break;
+
+	default:
+		break;
+	}
+}
+
+void SalesResults::Update(Uint32 timeStep) {
+	// Update timers
+	this->UpdateEventTimers();
+
+	// Return to title screen if quitting
+	if (this->EventFlags.ExitToTitleScreen) {
+		// Stop current music
+		Mix_HaltMusic();
+		// Go to title.
+		this->mManager->StartScene(Scene_TitleScreen);
+	}
+}
+
+void SalesResults::Render() {
+	// Render graphics to buffer
+	// If I find any game logic in here, I'll slap myself silly
+	for (int i = 0; i < (int) this->mImages.size(); i++) {
+		if (this->mImages[i]->IsVisible())
+			this->mManager->GetGraphics()->DrawTextureAtLocation(
+				this->mImages[i]->GetImage()->texture,
+				this->mImages[i]->GetImage()->rect,
+				this->mImages[i]->GetDrawRect(),
+				this->mImages[i]->GetDrawAngle()
+			);
+	}
+}
+
+//// SetPrices funcs
+ImageData* SalesResults::AddSalesResultsText(std::string _text, int _x, int _y) {
+	ImageData* textImage = this->AddText(_text, _x, _y);
+	this->SalesResultsText.push_back(textImage);
+	return textImage;
+}
+
+void SalesResults::GetCurrentPlayerInventory() {
+	// Clear current sell item list
+	this->SellItems.clear();
+	// Get all player items with inventory greater than 0
+	std::for_each(
+		this->mPlayerData->GetInventory()->begin(),
+		this->mPlayerData->GetInventory()->end(),
+		[this](ItemData* &_item) { if (_item->GetBoughtQuantity() > 0 && _item->GetType() != ItemType::ItemType_Ad) this->SellItems.push_back(_item); });
+}
+
+//// Scene Events
+void SalesResults::SEvent_ShowSalesResultsText() {
+	for (std::vector<ImageData*>::iterator it = this->SalesResultsText.begin(); it != this->SalesResultsText.end(); it++)
+		(*it)->SetVisible(true);
+}
+
+void SalesResults::SEvent_HideSalesResultsText() {
+	for (std::vector<ImageData*>::iterator it = this->SalesResultsText.begin(); it != this->SalesResultsText.end(); it++)
+		(*it)->SetVisible(false);
+}
+
+void SalesResults::SEvent_NextDay() {
+	// Set player day
+	this->mPlayerData->SetDay(this->mPlayerData->GetDay() + 1);
+	// Start market scene
+	this->mManager->StartScene(Scene_Market);
+}

--- a/TrySomethingNew/Scenes/Scene.h
+++ b/TrySomethingNew/Scenes/Scene.h
@@ -22,6 +22,7 @@ class Intro;
 class Market;
 class SetPrices;
 class DaySales;
+class SalesResults;
 
 //// Scene name enum
 enum SceneName {
@@ -30,7 +31,8 @@ enum SceneName {
 	Scene_Intro,		// Intro
 	Scene_Market,		// Market
 	Scene_SetPrices,	// Set Prices
-	Scene_DaySales		// Day Sales
+	Scene_DaySales,		// Day Sales
+	Scene_SalesResults	// Sales Results
 };
 
 //// Scene class
@@ -498,6 +500,46 @@ public:
 	void SEvent_DayRuntime2();
 	void SEvent_DayRuntime3();
 	void SEvent_DayRuntimeEnd();
+};
+
+class SalesResults : public Scene {
+protected:
+	// Sales Results screen text and text boxes
+	std::vector<ImageData*> SalesResultsText;
+	std::vector<ItemData*> SellItems;
+
+	struct {
+		ImageData* PlayerMoneyAmount;
+	} TextObjects;
+
+	struct {
+		bool ExitToTitleScreen;
+		bool ExitResults;
+	} EventFlags;
+
+public:
+	// Scene ctor
+	SalesResults();
+
+	// Scene funcs
+	void ResetFlags();
+	void LoadGameObjects();
+	void LoadEventTimers();
+	void LoadImagesText();
+	void SceneStart();
+	void HandleEvent(SDL_Event* Event);
+	void Update(Uint32 timeStep);
+	void Render();
+
+	// SalesResults funcs
+	ImageData* AddSalesResultsText(std::string _text, int _x, int _y);
+	void GetCurrentPlayerInventory();
+
+	//// Events
+	// Show/Hide Events
+	void SEvent_ShowSalesResultsText();
+	void SEvent_HideSalesResultsText();
+	void SEvent_NextDay();
 };
 
 #endif

--- a/TrySomethingNew/Scenes/SetPrices.cpp
+++ b/TrySomethingNew/Scenes/SetPrices.cpp
@@ -382,6 +382,11 @@ void SetPrices::SEvent_ExitGuide() {
 }
 
 void SetPrices::SEvent_OpenShop() {
+	// If all prices are not set, stay in shop.
+	for (std::vector<ItemData*>::iterator it = this->SellItems.begin(); it != this->SellItems.end(); it++) {
+		if ((*it)->GetSellPrice() <= 0)
+			return;
+	}
 	// Set player sell prices
 	for (std::vector<ItemData*>::iterator it = this->SellItems.begin(); it != this->SellItems.end(); it++)
 		this->mPlayerData->GetInventoryItem((*it)->GetName())->SetSellPrice((*it)->GetSellPrice());

--- a/TrySomethingNew/TrySomethingNew.vcxproj
+++ b/TrySomethingNew/TrySomethingNew.vcxproj
@@ -147,6 +147,7 @@
     <ClCompile Include="Scenes\Intro.cpp" />
     <ClCompile Include="Scenes\MainMenu.cpp" />
     <ClCompile Include="Scenes\Market.cpp" />
+    <ClCompile Include="Scenes\SalesResults.cpp" />
     <ClCompile Include="Scenes\Scene.cpp" />
     <ClCompile Include="Scenes\SetPrices.cpp" />
     <ClCompile Include="Scenes\TitleScreen.cpp" />

--- a/TrySomethingNew/TrySomethingNew.vcxproj.filters
+++ b/TrySomethingNew/TrySomethingNew.vcxproj.filters
@@ -84,6 +84,9 @@
     <ClCompile Include="GameObjects\CustomerObject.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Scenes\SalesResults.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Assets.h">


### PR DESCRIPTION
- SalesResults.cpp
-- Added Sales Results screen, will show player what was sold and how much money was made off of it before starting next day.

- Scene.cpp
-- Added SalesResults class and references elsewhere.

- SceneManager.cpp
-- Added SalesResults to scene list

- SetPrices.cpp
-- Extra check added before opening shop to make sure all prices have a greater-than-0 value.

- Market.cpp
-- Player Inventory cleared when starting Market scene.
-- BoughtQuantity now tracked in Market::SEvent_EndItemQtyEntry().
-- Player BoughtQuantity for items set in Market::SEvent_Leave().

- DaySales.cpp
-- Day/Money text positions moved up a bit to match SalesResults text.
-- Total Item Sales tracked in DaySales::GetPurchase().
-- DaySales::SEvent_DayRuntimeEnd() updates player inventory with item sales and changes to SalesResults. Day increase moved to SalesResults leave event.

- PlayerData.h
-- PlayerData::ClearInventory() added.

- PlayerData.cpp
-- PlayerData::ClearInventory() implemented, will reset inventory to initial state.
-- Forecast weather/event rates adjusted to make special forecasts a tad rarer.

- ItemData.h
-- ItemData::BoughtQuantity, ItemData::SalesTotal vars added, along with helper methods GetBoughtQuantity(), GetSalesTotal(), SetBoughtQuantity(), and AddSalesTotal().

- ItemData.cpp
-- BoughtQuantity and SalesTotal initialized in ItemData ctor.