### PR TITLE
Intro Scene Rework (Enter to skip, tidying up)

### DIFF
--- a/TrySomethingNew/Scenes/Intro.cpp
+++ b/TrySomethingNew/Scenes/Intro.cpp
@@ -1,6 +1,4 @@
 #include "Assets.h"
-#include "Camera.h"
-#include "GameObjects\GameObject.h"
 #include "Graphics.h"
 #include "Scenes\Scene.h"
 #include "SceneManager.h"
@@ -13,47 +11,53 @@ Intro::Intro() {
 void Intro::ResetFlags() {
 	// Set flags to false
 	this->EventFlags.ExitToTitleScreen = false;
+	this->EventFlags.IntroScreen2 = false;
+	this->EventFlags.IntroScreen3 = false;
 	this->EventFlags.EditName = false;
 	this->EventFlags.ShopNamed = false;
 }
 
-void Intro::LoadGameObjects() {
-	this->mGameObjects.clear();
-}
-
 void Intro::LoadEventTimers() {
+	// Clear existing timers
 	this->mEventTimers.clear();
 
 	// Init event timers
-	this->EventTimers.IntroDate1 = this->AddEventTimer(new EventTimer(std::bind(&Intro::SEvent_1, this), (Uint32) 2500));
-	this->EventTimers.IntroDate2 = this->AddEventTimer(new EventTimer(std::bind(&Intro::SEvent_2, this), (Uint32) 2500));
-	this->EventTimers.IntroText1 = this->AddEventTimer(new EventTimer(std::bind(&Intro::SEvent_3, this), (Uint32) 9000));
-	this->EventTimers.IntroText2 = this->AddEventTimer(new EventTimer(std::bind(&Intro::SEvent_4, this), (Uint32) 9000));
-	this->EventTimers.ToMarket = this->AddEventTimer(new EventTimer(std::bind(&Intro::SEvent_ToMarket, this), (Uint32) 9000));
+	this->EventTimers.IntroScreen1_Date = this->AddEventTimer(new EventTimer(std::bind(&Intro::SEvent_IntroScreen1_ShowLocation, this), (Uint32) 2500));
+	this->EventTimers.IntroScreen1_Location = this->AddEventTimer(new EventTimer(std::bind(&Intro::SEvent_IntroScreen2_Show, this), (Uint32) 2500));
+	this->EventTimers.IntroScreen2 = this->AddEventTimer(new EventTimer(std::bind(&Intro::SEvent_IntroScreen3_Show, this), (Uint32) 9000));
+	this->EventTimers.IntroScreen3 = this->AddEventTimer(new EventTimer(std::bind(&Intro::SEvent_NameEntryScreen_Show, this), (Uint32) 9000));
 }
 
 void Intro::LoadImagesText() {
 	// Clear any existing drawn text.
 	this->mImages.clear();
 
-	// Image objects
+	//// Image objects
+	// Intro Screen 2
 	this->Images.Wall1 = new ImageData();
 	this->Images.Wall1->SetImage(&Assets::Instance()->images.Wall1);
 	this->mImages.push_back(this->Images.Wall1);
+	// Intro Screen 3
 	this->Images.Wall2 = new ImageData();
 	this->Images.Wall2->SetImage(&Assets::Instance()->images.Wall2);
 	this->mImages.push_back(this->Images.Wall2);
 
-	// Text objects
-	this->TextObjects.OpeningDate = this->AddText("DECEMBER, 1989", 88, 88);
-	this->TextObjects.OpeningLocation = this->AddText("BERLIN, WEST GERMANY", 67, 96);
-	this->TextObjects.IntroText1 = this->AddText("THE BERLIN WALL NO LONGER SPLITS EAST\nAND WEST GERMANY. AFTER THREE DECADES,\nFAMILIES AND FRIENDS CAN REUNITE.", 7, 164);
-	this->TextObjects.IntroText2 = this->AddText("CAPITALISM SEES THIS CLOSING RIFT AND\nHAS STEPPED IN TO GIVE EACH SIDE A\nTASTE OF THE OTHER...FOR A SMALL COST.", 7, 164);
+	//// Text objects
+	// Intro Screen 1
+	this->TextObjects.OpeningDate = this->AddText("DECEMBER, 1989", 91, 90);
+	this->TextObjects.OpeningLocation = this->AddText("BERLIN, WEST GERMANY", 70, 99);
+	// Intro Screen 2
+	this->TextObjects.IntroScreen2 = this->AddText("THE BERLIN WALL NO LONGER SPLITS EAST\nAND WEST GERMANY. AFTER THREE DECADES,\nFAMILIES AND FRIENDS CAN REUNITE.", 7, 164);
+	// Intro Screen 3
+	this->TextObjects.IntroScreen3 = this->AddText("CAPITALISM SEES THIS CLOSING RIFT AND\nHAS STEPPED IN TO GIVE EACH SIDE A\nTASTE OF THE OTHER...FOR A SMALL COST.", 7, 164);
+	// Shop Name Entry
 	this->TextObjects.SettingBlurb = this->AddText("       *** DEINE GESCHICHTE ***\n\n    YOU HAVE ARRIVED FROM THE UNITED STATES TO SET UP SHOP OUTSIDE OF THE BRANDENBURG GATE. THERE ARE MANY EAST AND WEST BERLINERS WALKING BY LOOKING TO BUY WARES THEY HAVE NEVER SEEN.\n\n    YOUR SHOP WILL NEED A NAME BEFORE YOUR BUSINESS CAN OPEN.\n", 7, 9);
 	this->TextObjects.EnterShopName = this->AddText("SHOP NAME:", 7, 108);
 	this->TextBoxObjects.ShopNameEntry = this->AddTextBox(25, 7, 117);
 	this->TextObjects.ShopIsSetUp = this->AddText("    AFTER COBBLING TOGETHER A SMALL SHACK ON THE OUTER PERIMETER OF THE WALL, YOU HAVE 50 DEUTSCHE MARKS (DM) LEFT TO BUY WARES.", 7, 135);
+	this->TextObjects.PressReturn = this->AddText("- PRESS RETURN -", 84, 180);
 
+	// Set all images to not visible
 	for (std::vector<ImageData*>::iterator it = this->mImages.begin(); it != this->mImages.end(); it++)
 		(*it)->SetVisible(false);
 }
@@ -68,10 +72,9 @@ void Intro::SceneStart() {
 	// Start with text entry off
 	SDL_StopTextInput();
 
-	// Load Game Objects
-	this->LoadGameObjects();
 	// Load Event Timers
 	this->LoadEventTimers();
+	
 	// Load Images and Text Images
 	this->LoadImagesText();
 
@@ -80,25 +83,32 @@ void Intro::SceneStart() {
 
 	// Display date text
 	this->TextObjects.OpeningDate->SetVisible(true);
+	
 	// Start screen timer
-	this->EventTimers.IntroDate1->StartEventTimer();
+	this->EventTimers.IntroScreen1_Date->StartEventTimer();
 }
 
 void Intro::HandleEvent(SDL_Event * Event) {
 	switch (Event->type) {
 	case SDL_KEYDOWN:
-		if (Event->key.keysym.sym == SDLK_ESCAPE) this->EventFlags.ExitToTitleScreen = true;
+		if (Event->key.keysym.sym == SDLK_ESCAPE) 
+			this->EventFlags.ExitToTitleScreen = true;
 		if (Event->key.keysym.sym == SDLK_RETURN) {
-			// Stop text entry when enter is pressed.
-			if (SDL_IsTextInputActive() && this->EventFlags.EditName) {
-				// Set state flags
-				this->EventFlags.EditName = false;
-				this->EventFlags.ShopNamed = true;
-				// Set player shop name
-				this->mPlayerData->SetName( *(this->TextBoxObjects.ShopNameEntry->GetText()) );
-				// Stop text input and disable text box
-				SDL_StopTextInput();
-				this->TextBoxObjects.ShopNameEntry->SetActive(false);
+			if (this->EventFlags.IntroScreen2) {
+				// Skip Intro Screen 2
+				this->SEvent_IntroScreen2_Skip();
+			}
+			else if (this->EventFlags.IntroScreen3) {
+				// Skip Intro Screen 3
+				this->SEvent_IntroScreen3_Skip();
+			}
+			else if (this->EventFlags.EditName) {
+				// Name shop (if text entered) and show blurb
+				this->SEvent_ShopNamed();
+			}
+			else if (this->EventFlags.ShopNamed) {
+				// Switch to Market screen
+				this->SEvent_ToMarket();
 			}
 		}
 		// If we're editing and hit backspace, erase a character.
@@ -135,12 +145,6 @@ void Intro::Update(Uint32 timeStep) {
 		// Go to title.
 		this->mManager->StartScene(Scene_TitleScreen);
 	}
-
-	if (this->EventFlags.ShopNamed && !this->TextObjects.ShopIsSetUp->IsVisible() && !this->EventTimers.ToMarket->isStarted()) {
-		this->TextObjects.ShopIsSetUp->SetVisible(true);
-		this->EventTimers.ToMarket->StartEventTimer();
-	}
-
 }
 
 void Intro::Render() {
@@ -157,44 +161,70 @@ void Intro::Render() {
 	}
 }
 
-void Intro::SEvent_1() {
+void Intro::SEvent_IntroScreen1_ShowLocation() {
 	// Show location text
 	this->TextObjects.OpeningLocation->SetVisible(true);
 	
 	// Start screen timer
-	this->EventTimers.IntroDate2->StartEventTimer();
+	this->EventTimers.IntroScreen1_Location->StartEventTimer();
 }
 
-void Intro::SEvent_2() {
+void Intro::SEvent_IntroScreen2_Show() {
+	// Set screen state
+	this->EventFlags.IntroScreen2 = true;
+
 	// Hide date/time text
 	this->TextObjects.OpeningDate->SetVisible(false);
 	this->TextObjects.OpeningLocation->SetVisible(false);
 
 	// Show image and text
 	this->Images.Wall1->SetVisible(true);
-	this->TextObjects.IntroText1->SetVisible(true);
+	this->TextObjects.IntroScreen2->SetVisible(true);
 
 	// Start screen timer
-	this->EventTimers.IntroText1->StartEventTimer();
+	this->EventTimers.IntroScreen2->StartEventTimer();
 }
 
-void Intro::SEvent_3() {
+void Intro::SEvent_IntroScreen2_Skip() {
+	// Halt timer
+	this->EventTimers.IntroScreen2->stop();
+	
+	// Advance to next screen
+	this->SEvent_IntroScreen3_Show();
+}
+
+void Intro::SEvent_IntroScreen3_Show() {
+	// Set screen state
+	this->EventFlags.IntroScreen2 = false;
+	this->EventFlags.IntroScreen3 = true;
+
 	// Hide previous image and text
 	this->Images.Wall1->SetVisible(false);
-	this->TextObjects.IntroText1->SetVisible(false);
+	this->TextObjects.IntroScreen2->SetVisible(false);
 
 	// Show image and text
 	this->Images.Wall2->SetVisible(true);
-	this->TextObjects.IntroText2->SetVisible(true);
+	this->TextObjects.IntroScreen3->SetVisible(true);
 
 	//Start screen timer
-	this->EventTimers.IntroText2->StartEventTimer();
+	this->EventTimers.IntroScreen3->StartEventTimer();
 }
 
-void Intro::SEvent_4() {
+void Intro::SEvent_IntroScreen3_Skip() {
+	// Halt timer
+	this->EventTimers.IntroScreen3->stop();
+
+	// Advance to next screen
+	this->SEvent_NameEntryScreen_Show();
+}
+
+void Intro::SEvent_NameEntryScreen_Show() {
+	// Set screen state
+	this->EventFlags.IntroScreen3 = false;
+
 	// Hide previous image and text
 	this->Images.Wall2->SetVisible(false);
-	this->TextObjects.IntroText2->SetVisible(false);
+	this->TextObjects.IntroScreen3->SetVisible(false);
 
 	// Show text
 	this->TextObjects.SettingBlurb->SetVisible(true);
@@ -207,6 +237,27 @@ void Intro::SEvent_4() {
 	SDL_StartTextInput();
 	this->EventFlags.EditName = true;
 	this->TextBoxObjects.ShopNameEntry->SetActive(this->EventFlags.EditName);
+}
+
+void Intro::SEvent_ShopNamed() {
+	// If no name is entered, ignore event.
+	if (this->TextBoxObjects.ShopNameEntry->GetText()->length() <= 0)
+		return;
+
+	// Set state flags
+	this->EventFlags.EditName = false;
+	this->EventFlags.ShopNamed = true;
+
+	// Set player shop name
+	this->mPlayerData->SetName(*(this->TextBoxObjects.ShopNameEntry->GetText()));
+	
+	// Stop text input and disable text box
+	SDL_StopTextInput();
+	this->TextBoxObjects.ShopNameEntry->SetActive(false);
+
+	// Display post-naming blurb
+	this->TextObjects.ShopIsSetUp->SetVisible(true);
+	this->TextObjects.PressReturn->SetVisible(true);
 }
 
 void Intro::SEvent_ToMarket() {

--- a/TrySomethingNew/Scenes/Scene.h
+++ b/TrySomethingNew/Scenes/Scene.h
@@ -120,11 +120,12 @@ protected:
 	struct {
 		ImageData* OpeningDate;
 		ImageData* OpeningLocation;
-		ImageData* IntroText1;
-		ImageData* IntroText2;
+		ImageData* IntroScreen2;
+		ImageData* IntroScreen3;
 		ImageData* SettingBlurb;
 		ImageData* EnterShopName;
 		ImageData* ShopIsSetUp;
+		ImageData* PressReturn;
 	} TextObjects;
 	
 	struct {
@@ -132,15 +133,16 @@ protected:
 	} TextBoxObjects;
 	
 	struct {
-		EventTimer* IntroDate1;
-		EventTimer* IntroDate2;
-		EventTimer* IntroText1;
-		EventTimer* IntroText2;
-		EventTimer* ToMarket;
+		EventTimer* IntroScreen1_Date;
+		EventTimer* IntroScreen1_Location;
+		EventTimer* IntroScreen2;
+		EventTimer* IntroScreen3;
 	} EventTimers;
 	
 	struct {
 		bool ExitToTitleScreen;
+		bool IntroScreen2;
+		bool IntroScreen3;
 		bool EditName;
 		bool ShopNamed;
 	} EventFlags;
@@ -151,7 +153,6 @@ public:
 
 	// Scene funcs
 	void ResetFlags();
-	void LoadGameObjects();
 	void LoadEventTimers();
 	void LoadImagesText();
 	void SceneStart();
@@ -160,10 +161,13 @@ public:
 	void Render();
 
 	// Scene Events
-	void SEvent_1();
-	void SEvent_2();
-	void SEvent_3();
-	void SEvent_4();
+	void SEvent_IntroScreen1_ShowLocation();
+	void SEvent_IntroScreen2_Show();
+	void SEvent_IntroScreen2_Skip();
+	void SEvent_IntroScreen3_Show();
+	void SEvent_IntroScreen3_Skip();
+	void SEvent_NameEntryScreen_Show();
+	void SEvent_ShopNamed();
 	void SEvent_ToMarket();
 };
 


### PR DESCRIPTION
- Scene.h
-- Renamed ImageData, EventTimer objects and SEvent funcs in Intro Scene to be more descriptive.
-- Added PressReturn ImageData.
-- Removed ToMarket Event timer. Advancing to the market will not be a timer anymore, that seemed silly.
-- IntroScreen2/3 EventFlags added to track screen states.
-- LoadGameObjects() func removed. It's not being used, begone with ye.
-- SEvents added for skipping second and third intro screens, and one added for naming shop.

- Intro.cpp
-- Comments added/changed for better documentation.
-- Removed Camera.h and GameObject.h includes. Not being used, gone.
-- New event flags implemented.
-- Intro Screen 1 text positions adjusted to align with text grid.
-- PressReturn ImageData implemented.
-- LoadGameObjects() removed; both definition and implementation in SceneStart().
-- HandleEvent() reworked to use SEvent structure.
-- Moved block of code from Update() into SEvent_ShopNamed().
-- New SEvents implemented. Allow skipping of second/third item screens and manual skipping of post-name entry blurb.