### PR TITLE
DaySales crash fix

### DIFF
--- a/TrySomethingNew/Scenes/DaySales.cpp
+++ b/TrySomethingNew/Scenes/DaySales.cpp
@@ -77,6 +77,7 @@ void DaySales::SceneStart() {
 	/// Set initial vars
 	this->EventFlags.Simulation = true;
 	this->Money = 0;
+	this->CustomerSpawnInterval = 0;
 	this->CustomerSpawnTotal = 0;
 
 	// Get player inventory
@@ -208,6 +209,8 @@ void DaySales::GenerateCustomers() {
 	int numCustomers = rand() % (10 + signs + (posters * 4) + (newsAds * 8)) + (1 + signs + (posters * 3) + (newsAds * 6));
 	// Mod numCustomers with weatherMod value
 	numCustomers = (int)((double)numCustomers * weatherMod);
+	// If numCustomers ends up at 0 (or less?), spawn at least one customer.
+	if (numCustomers <= 0) numCustomers = 1;
 
 	// Get customer spawn rate
 	this->CustomerSpawnInterval = ((this->DaySegmentLength * 3) - 1000) / numCustomers;

--- a/TrySomethingNew/Scenes/SetPrices.cpp
+++ b/TrySomethingNew/Scenes/SetPrices.cpp
@@ -206,6 +206,8 @@ void SetPrices::Update(Uint32 timeStep) {
 
 	// Return to title screen if quitting
 	if (this->EventFlags.ExitToTitleScreen) {
+		// Cleanup scene
+		this->Cleanup();
 		// Stop current music
 		Mix_HaltMusic();
 		// Go to title.
@@ -225,6 +227,21 @@ void SetPrices::Render() {
 				this->mImages[i]->GetDrawAngle()
 			);
 	}
+}
+
+void SetPrices::Cleanup() {
+	// Clear loaded images
+	for (std::vector<ImageData*>::iterator it = this->mImages.begin(); it != this->mImages.end(); it++)
+		delete *it;
+
+	// Clear vectors
+	this->mImages.clear();
+	this->SetPricesText.clear();
+	this->ItemTextBoxObjects.clear();
+	this->SellItems.clear();
+
+	// Stop timers
+	this->EventTimers.ErrorText->stop();
 }
 
 //// SetPrices funcs
@@ -431,6 +448,9 @@ void SetPrices::SEvent_OpenShop() {
 	for (std::vector<ItemData*>::iterator it = this->SellItems.begin(); it != this->SellItems.end(); it++)
 		this->mPlayerData->GetInventoryItem((*it)->GetName())->SetSellPrice((*it)->GetSellPrice());
 	
+	// Cleanup scene
+	this->Cleanup();
+
 	// Stop Music
 	Mix_HaltMusic();
 

--- a/TrySomethingNew/Scenes/SetPrices.h
+++ b/TrySomethingNew/Scenes/SetPrices.h
@@ -63,6 +63,7 @@ public:
 	void HandleEvent(SDL_Event* Event);
 	void Update(Uint32 timeStep);
 	void Render();
+	void Cleanup();
 
 	// SetPrices funcs
 	ImageData* AddSetPricesText(std::string _text, int _x, int _y);


### PR DESCRIPTION
- DaySales.cpp
-- Bug fixed in GenerateCustomers() where a low number of customers with rainy weather would generate 0 customers. This crashed the for loop immediately after. Now one customer will always spawn minimum.

- SetPrices.h
-- Cleanup() added to test if existing assets were possibly causing a crash. All scene images and vectors are cleared prior to leaving for the next scene. Timers are stopped as well.

- SetPrices.cpp
-- Cleanup() implemented.
-- Cleanup() calls added to TitleScreen and DaySales exits.